### PR TITLE
Feature: minify

### DIFF
--- a/conf/tasks/minify.js
+++ b/conf/tasks/minify.js
@@ -5,7 +5,7 @@
 
   const gulp = require('gulp')
   , paths    = require('../paths')
-  , minify   = require('gulp-cssmin')
+  , minify   = require('gulp-clean-css')
   , rename   = require('gulp-rename');
 
     gulp.task('minify', function onMinifyCss() {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^3.1.0",
     "gulp-clean": "^0.3.2",
-    "gulp-cssmin": "^0.1.7",
+    "gulp-clean-css": "^2.0.12",
     "gulp-header": "^1.8.7",
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^2.3.2",


### PR DESCRIPTION
Replace `gulp-cssmin` with `gulp-clean-css` to improve maintenance:

`gulp-cssmin`

> Duplicate of gulp-minify-css

[Source](https://github.com/chilijung/gulp-cssmin)

`gulp-minify-css`

> This package has been deprecated. Please use [gulp-clean-css](https://github.com/scniro/gulp-clean-css) instead.

[Source](https://www.npmjs.com/package/gulp-minify-css)
